### PR TITLE
Update setup.py to handle IPython 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 try:
     from setuptools import setup
 except ImportError:
@@ -14,10 +16,17 @@ setup(
     license='MIT',
     description='A test-driven framework for formally validating scientific models against data.',
     long_description="",
+    
+    # IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2
+    if sys.version_info < (3,3):
+        ipython = "ipython>=5.1,<6.0"
+    else:
+        ipython = "ipython>=5.1"
+    
     install_requires=['cypy>=0.2',
                       'quantities==999',
                       'pandas>=0.18',
-                      'ipython>=5.1',
+                      ipython,
                       'matplotlib',
                       'bs4',
                       'lxml',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
+# IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2
+if sys.version_info < (3,3):
+    ipython = "ipython>=5.1,<6.0"
+else:
+    ipython = "ipython>=5.1"    
+    
 setup(
     name='sciunit',
     version='0.1.5.8',
@@ -15,13 +21,7 @@ setup(
     url='http://sciunit.scidash.org',
     license='MIT',
     description='A test-driven framework for formally validating scientific models against data.',
-    long_description="",
-    
-    # IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2
-    if sys.version_info < (3,3):
-        ipython = "ipython>=5.1,<6.0"
-    else:
-        ipython = "ipython>=5.1"
+    long_description="",      
     
     install_requires=['cypy>=0.2',
                       'quantities==999',


### PR DESCRIPTION
Beginning with version 6.0, IPython stopped supporting compatibility with Python versions lower than 3.3 including all versions of Python 2.7. So we need to ensure that IPython 5.x is installed with Python <3.3.