### PR TITLE
Access new column 'models' in DataFrame self

### DIFF
--- a/sciunit/scores/collections_m2m.py
+++ b/sciunit/scores/collections_m2m.py
@@ -61,7 +61,7 @@ class ScoreMatrixM2M(pd.DataFrame):
             items = [test]+models
         super(ScoreMatrixM2M,self).__init__(data=scores, index=items, columns=items)
         self.test = test
-        self.models = models
+        self['models'] = models
 
     def __getitem__(self, item):
         if isinstance(item,(Test,Model)):


### PR DESCRIPTION
The current form `self.models = models` leads to a warning

> UserWarning: Pandas doesn't allow columns to be created via a new attribute name - see https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access

because it is not the proper way to access a column that has be newly created. The correct way is `self['models'] = models`.