### PR TITLE
Unexpected parameter fix

### DIFF
--- a/sciunit/suites.py
+++ b/sciunit/suites.py
@@ -88,8 +88,7 @@ class TestSuite(SciUnit, TestWeighted):
         sm = ScoreMatrix(self.tests, models)
         for test in self.tests:
             for model in models:
-                sm.loc[model, test] = test.check(model,
-                                                 require_extra=require_extra)
+                sm.loc[model, test] = test.check(model)
         return sm
 
     def check_capabilities(self, model, skip_incapable=False,


### PR DESCRIPTION
Checking compatibility is not working cause check got an unexpected keywork argument 

Here you can see that parameter is missing:
https://github.com/scidash/sciunit/blob/dev/sciunit/tests.py#L284
