### PR TITLE
make judging from features more convenient, this method expects uses …

### DIFF
--- a/sciunit/models/runnable.py
+++ b/sciunit/models/runnable.py
@@ -38,14 +38,13 @@ class RunnableModel(Model,
 
         Args:
             backend (Union[str, tuple, list, None]): One or more name(s) of backend(s).
-                                                     The name of backend should be registered before using. 
+                                                     The name of backend should be registered before using.
 
         Raises:
             TypeError: Backend must be string, tuple, list, or None
             Exception: The backend was not found.
         """
         if inspect.isclass(backend) and Backend in backend.__bases__:
-            print(backend.__name__)
             name = backend.__name__
             args = []
             kwargs = {}

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -116,6 +116,10 @@ class Test(SciUnit):
                           'type': 'dict'}
             schema = {'observation': schema}
             v = ObservationValidator(schema, test=self)
+            if float(observation['std']) == 0.0:
+                print(float(observation['std']) != 0.0)
+                print('std == 0 error')
+                raise ObservationError(v.errors)
             if not v.validate({'observation': observation}):
                 raise ObservationError(v.errors)
         return observation
@@ -369,6 +373,97 @@ class Test(SciUnit):
         # 6.
         self._bind_score(score, model, self.observation, prediction)
 
+
+
+    def _presupplied_feature_judge(self, skip_incapable: bool=True) -> Score:
+        """Generate a score for the model (internal API use only).
+
+        Args:
+            model (Model): A sciunit model instance.
+            skip_incapable (bool, optional): [description]. Defaults to True.
+
+        Returns:
+            Score: The generated score.
+        """
+
+        # 1.
+        
+        prediction = self.prediction
+        self.check_prediction(prediction)
+
+        # 3. Validate observation and compute score
+        validated = self.validate_observation(self.observation)
+
+        if validated is not None:
+            self.observation = validated
+
+        score = self.compute_score(self.observation, prediction)
+
+        if self.converter:
+            score = self.converter.convert(score)
+
+        # 4.
+        self.check_score_type(score)
+
+        # 5.
+        self.score = score
+        return score
+
+
+    def feature_judge(self, skip_incapable: bool=False, stop_on_error: bool=True,
+              deep_error: bool=False) -> Score:
+        """Generate a score for the provided model (public method).
+
+        Operates as follows:
+        1. Checks if the model has all the required capabilities. If it does
+           not, and skip_incapable=False, then a `CapabilityError` is raised.
+        2. Calls generate_prediction to generate a prediction.
+        3. Calls score_prediction to generate a score.
+        4. Checks that the score is of score_type, raising an
+           InvalidScoreError.
+        5. Equips the score with metadata:
+           a) A reference to the model, in attribute model.
+           b) A reference to the test, in attribute test.
+           c) A reference to the prediction, in attribute prediction.
+           d) A reference to the observation, in attribute observation.
+        6. Returns the score.
+
+        If stop_on_error is true (default), exceptions propagate upward. If
+        false, an ErrorScore is generated containing the exception.
+
+        If deep_error is true (not default), the traceback will contain the
+        actual code execution error, instead of the content of an ErrorScore.
+
+        Args:
+            model (Model): A sciunit model instance
+            skip_incapable (bool, optional): [description]. Defaults to False.
+            stop_on_error (bool, optional): [description]. Defaults to True.
+            deep_error (bool, optional): [description]. Defaults to False.
+
+        Raises:
+            score.score: [description]
+
+        Returns:
+            Score: The generated score for the provided model.
+        """
+
+
+        if deep_error:
+            score = self._presupplied_feature_judge(skip_incapable=skip_incapable)
+        else:
+            try:
+                score = self._presupplied_feature_judge(skip_incapable=skip_incapable)
+            except CapabilityError as e:
+                score = NAScore(str(e))
+                score.feature = self.prediction
+                score.test = self
+            except Exception as e:
+                e.stack = traceback.format_exc()
+                score = ErrorScore(e)
+                score.feature = self.prediction
+                score.test = self
+        if isinstance(score, ErrorScore) and stop_on_error:
+            raise score.score  # An exception.
         return score
 
     def judge(self, model: Model, skip_incapable: bool=False, stop_on_error: bool=True,


### PR DESCRIPTION
This method expects users to have pre-existing code that performs something like judge generate prediction. Prediction is then just treated as a settable object attribute, which can be updated.

Doing things this way is more amenable to high throughput feature generation. Ie if EFEL generates 100 new features per model.