### PR TITLE
Rename Drafter Config File

### DIFF
--- a/.github/release-drafter-template.yml
+++ b/.github/release-drafter-template.yml
@@ -2,4 +2,3 @@ template: |
   ## What’s Changed
 
   $CHANGES
-  

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,8 +22,8 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
+        with:
+          config-name: release-drafter-template.yml
         #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After testing it in my repository, I found that it will be fine even the GitHub Action temporally failed, because the GitHub Action workflow executed for this PR is the action workflow in the master branch, and after this PR, the action workflow will be updated. Then, it should works fine.