### PR TITLE
Change trigger of Upload Python Package action to `published`

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
`created` event trigger does not work with release drafter because we never create the release but the drafter does. And what we do is publishing the release created by the drafter. So, change the trigger to `published` may be appropriate.