### PR TITLE
Fix caching for repos without remotes

### DIFF
--- a/sciunit/base.py
+++ b/sciunit/base.py
@@ -211,23 +211,6 @@ class Versioned(object):
 
     version = property(get_version)
 
-    def old_get_remote(self, remote: str = "origin", **kwargs) -> Remote:
-        """Get a git remote object for this instance.
-
-        Args:
-            remote (str, optional): The remote Git repo. Defaults to 'origin'.
-
-        Returns:
-            Remote: The git remote object for this instance.
-        """
-        repo = kwargs["repo"] if "repo" in kwargs else self.get_repo()
-        if repo is not None:
-            remotes = {r.name: r for r in repo.remotes}
-            r = repo.remotes[0] if remote not in remotes else remotes[remote]
-        else:
-            r = None
-        return r
-
     def get_remote(self, remote_name: str = "origin", **kwargs) -> Remote:
         """Get a git remote object for this instance.
 

--- a/sciunit/base.py
+++ b/sciunit/base.py
@@ -211,22 +211,30 @@ class Versioned(object):
 
     version = property(get_version)
 
-    def get_remote(self, remote: str = "origin") -> Remote:
+    def get_remote(self, remoteName: str = "origin") -> Remote:
         """Get a git remote object for this instance.
 
         Args:
-            remote (str, optional): The remote Git repo. Defaults to 'origin'.
+            remoteName (str, optional): The remote Git repo. Defaults to 'origin'.
 
         Returns:
             Remote: The git remote object for this instance.
         """
         repo = self.get_repo()
-        if repo is not None:
-            remotes = {r.name: r for r in repo.remotes}
-            r = repo.remotes[0] if remote not in remotes else remotes[remote]
+
+        if repo is None:
+            return None
+
+        if len(repo.remotes) == 0:
+            return None
+
+        matching = [r for r in repo.remotes if r.name == remoteName]
+        if (len(matching) > 0):
+            # => Remote with remoteName
+            return matching[0]
         else:
-            r = None
-        return r
+            # => just any first Remote
+            return repo.remotes[0]
 
     def get_remote_url(self, remote: str = "origin", cached: bool = True) -> str:
         """Get a git remote URL for this instance.

--- a/sciunit/base.py
+++ b/sciunit/base.py
@@ -211,7 +211,24 @@ class Versioned(object):
 
     version = property(get_version)
 
-    def get_remote(self, remote_name: str = "origin") -> Remote:
+    def old_get_remote(self, remote: str = "origin", **kwargs) -> Remote:
+        """Get a git remote object for this instance.
+
+        Args:
+            remote (str, optional): The remote Git repo. Defaults to 'origin'.
+
+        Returns:
+            Remote: The git remote object for this instance.
+        """
+        repo = kwargs["repo"] if "repo" in kwargs else self.get_repo()
+        if repo is not None:
+            remotes = {r.name: r for r in repo.remotes}
+            r = repo.remotes[0] if remote not in remotes else remotes[remote]
+        else:
+            r = None
+        return r
+
+    def get_remote(self, remote_name: str = "origin", **kwargs) -> Remote:
         """Get a git remote object for this instance.
 
         Args:
@@ -220,7 +237,7 @@ class Versioned(object):
         Returns:
             Remote: The git remote object for this instance.
         """
-        repo = self.get_repo()
+        repo = kwargs["repo"] if "repo" in kwargs else self.get_repo()
 
         if repo is None:
             return None

--- a/sciunit/base.py
+++ b/sciunit/base.py
@@ -211,11 +211,11 @@ class Versioned(object):
 
     version = property(get_version)
 
-    def get_remote(self, remoteName: str = "origin") -> Remote:
+    def get_remote(self, remote_name: str = "origin") -> Remote:
         """Get a git remote object for this instance.
 
         Args:
-            remoteName (str, optional): The remote Git repo. Defaults to 'origin'.
+            remote_name (str, optional): The remote Git repo. Defaults to 'origin'.
 
         Returns:
             Remote: The git remote object for this instance.
@@ -228,9 +228,9 @@ class Versioned(object):
         if len(repo.remotes) == 0:
             return None
 
-        matching = [r for r in repo.remotes if r.name == remoteName]
+        matching = [r for r in repo.remotes if r.name == remote_name]
         if (len(matching) > 0):
-            # => Remote with remoteName
+            # => Remote with remote_name
             return matching[0]
         else:
             # => just any first Remote

--- a/sciunit/unit_test/base_tests.py
+++ b/sciunit/unit_test/base_tests.py
@@ -70,29 +70,5 @@ class BaseCase(unittest.TestCase):
         # Testing .get_remote_url()
         self.assertIsInstance(ver.get_remote_url("I am not a remote"), str)
 
-    def test_OldVersioned(self):
-        from git import Repo
-        from sciunit.base import Versioned
-
-        ver = Versioned()
-
-        # Testing .old_get_remote()
-        # 1. Checking our sciunit .git repo
-        # (to make sure .old_get_remote() works with real repos too!)
-        self.assertEqual("origin", ver.old_get_remote("I am not a remote").name)
-        self.assertEqual("origin", ver.old_get_remote().name)
-        # 2. Checking NO .git repo
-        self.assertEqual(None, ver.old_get_remote(repo=None))
-        # 3. Checking a .git repo without remotes
-        git_repo = Repo.init(tmp_folder_path / "git_repo_old")
-        # @Rick, this should pass!
-        self.assertRaises(IndexError, lambda: ver.old_get_remote(repo=git_repo))
-        # 4. Checking a .git repo with remotes
-        origin = git_repo.create_remote("origin", "https://origin.com")
-        beta = git_repo.create_remote('beta', "https://beta.com")
-        self.assertEqual(origin, ver.old_get_remote(repo=git_repo))
-        self.assertEqual(origin, ver.old_get_remote("not a remote", repo=git_repo))
-        self.assertEqual(beta, ver.old_get_remote("beta", repo=git_repo))
-
 if __name__ == "__main__":
     unittest.main()

--- a/sciunit/unit_test/base_tests.py
+++ b/sciunit/unit_test/base_tests.py
@@ -34,8 +34,10 @@ class BaseCase(unittest.TestCase):
         from sciunit.base import Versioned
 
         ver = Versioned()
-        self.assertEqual("origin", str(ver.get_remote("I am not a remote")))
-        self.assertEqual("origin", str(ver.get_remote()))
+        # We check our sciunit .git repo here (and we do have a remote named "origin"!)
+        self.assertEqual("origin", ver.get_remote("I am not a remote").name)
+        self.assertEqual("origin", ver.get_remote().name)
+
         self.assertIsInstance(ver.get_repo(), Repo)
         self.assertIsInstance(ver.get_remote_url("I am not a remote"), str)
 

--- a/sciunit/unit_test/base_tests.py
+++ b/sciunit/unit_test/base_tests.py
@@ -1,8 +1,21 @@
 import unittest
 
+from pathlib import Path
+
+tmp_folder_path = Path(__file__).parent / "delete_after_tests"
 
 class BaseCase(unittest.TestCase):
     """Unit tests for config files"""
+
+    @classmethod
+    def setUpClass(cls):
+        Path(tmp_folder_path).mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+        if tmp_folder_path.exists() and tmp_folder_path.is_dir():
+            shutil.rmtree(tmp_folder_path)
 
     def test_deep_exclude(self):
         from sciunit.base import deep_exclude
@@ -30,17 +43,56 @@ class BaseCase(unittest.TestCase):
 
     def test_Versioned(self):
         from git import Repo
-
         from sciunit.base import Versioned
 
         ver = Versioned()
-        # We check our sciunit .git repo here (and we do have a remote named "origin"!)
+
+        # Testing .get_remote()
+        # 1. Checking our sciunit .git repo
+        # (to make sure .get_remote() works with real repos too!)
         self.assertEqual("origin", ver.get_remote("I am not a remote").name)
         self.assertEqual("origin", ver.get_remote().name)
+        # 2. Checking NO .git repo
+        self.assertEqual(None, ver.get_remote(repo=None))
+        # 3. Checking a .git repo without remotes
+        git_repo = Repo.init(tmp_folder_path / "git_repo")
+        self.assertEqual(None, ver.get_remote(repo=git_repo))
+        # 4. Checking a .git repo with remotes
+        origin = git_repo.create_remote("origin", "https://origin.com")
+        beta = git_repo.create_remote('beta', "https://beta.com")
+        self.assertEqual(origin, ver.get_remote(repo=git_repo))
+        self.assertEqual(origin, ver.get_remote("not a remote", repo=git_repo))
+        self.assertEqual(beta, ver.get_remote("beta", repo=git_repo))
 
+        # Testing .get_repo()
         self.assertIsInstance(ver.get_repo(), Repo)
+
+        # Testing .get_remote_url()
         self.assertIsInstance(ver.get_remote_url("I am not a remote"), str)
 
+    def test_OldVersioned(self):
+        from git import Repo
+        from sciunit.base import Versioned
+
+        ver = Versioned()
+
+        # Testing .old_get_remote()
+        # 1. Checking our sciunit .git repo
+        # (to make sure .old_get_remote() works with real repos too!)
+        self.assertEqual("origin", ver.old_get_remote("I am not a remote").name)
+        self.assertEqual("origin", ver.old_get_remote().name)
+        # 2. Checking NO .git repo
+        self.assertEqual(None, ver.old_get_remote(repo=None))
+        # 3. Checking a .git repo without remotes
+        git_repo = Repo.init(tmp_folder_path / "git_repo_old")
+        # @Rick, this should pass!
+        self.assertRaises(IndexError, lambda: ver.old_get_remote(repo=git_repo))
+        # 4. Checking a .git repo with remotes
+        origin = git_repo.create_remote("origin", "https://origin.com")
+        beta = git_repo.create_remote('beta', "https://beta.com")
+        self.assertEqual(origin, ver.old_get_remote(repo=git_repo))
+        self.assertEqual(origin, ver.old_get_remote("not a remote", repo=git_repo))
+        self.assertEqual(beta, ver.old_get_remote("beta", repo=git_repo))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
SciUnit 0.2.4 (and up) wasn't working for me locally with the Backend (because I do have a .git repo, but don't have any remotes), this fixes it.

But I wonder - why do we need this, how is this useful for caching?
> Put the commit # and origin of the current working copy into every model/test/capability created from a python session inside that working copy.
(https://github.com/scidash/sciunit/issues/53).

![image](https://user-images.githubusercontent.com/7578559/123541166-7f70e400-d75c-11eb-9608-d2bbc1cbb3c8.png)