### PR TITLE
Enable caching of model specific test predictions

### DIFF
--- a/sciunit/models/backends.py
+++ b/sciunit/models/backends.py
@@ -164,7 +164,8 @@ class Backend(SciUnit):
         disk_cache.close()
 
     def set_cache(self, results: Any, key: str = None) -> bool:
-        """Store result in disk and/or memory cache for key 'key'.
+        """Store result in disk and/or memory cache for key 'key', depending
+        on whether `use_disk_cache` and `use_memory_cache` are True.
 
         Args:
             results (Any): [description]

--- a/sciunit/models/backends.py
+++ b/sciunit/models/backends.py
@@ -5,7 +5,7 @@ import pickle
 import shelve
 import tempfile
 from pathlib import Path
-from typing import Any, Union,
+from typing import Any, Union
 
 from sciunit.base import SciUnit, config
 

--- a/sciunit/models/backends.py
+++ b/sciunit/models/backends.py
@@ -5,7 +5,7 @@ import pickle
 import shelve
 import tempfile
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Union,
 
 from sciunit.base import SciUnit, config
 
@@ -119,6 +119,24 @@ class Backend(SciUnit):
         disk_cache.close()
         return self._results
 
+    def get_cache(self, key: str = None) -> Any:
+        """Return result in disk or memory cache for key 'key' or None if not
+        found. If both `use_disk_cache` and `use_memory_cache` are True, the
+        memory cache is returned.
+
+        Returns:
+            Any: The cache for key 'key' or None if not found.
+        """
+        if self.use_memory_cache:
+            result = self.get_memory_cache(key=key)
+            if result is not None:
+                return result
+        if self.use_disk_cache:
+            result = self.get_disk_cache(key=key)
+            if result is not None:
+                return result
+        return None
+
     def set_memory_cache(self, results: Any, key: str = None) -> None:
         """Store result in memory cache with key matching model state.
 
@@ -144,6 +162,24 @@ class Backend(SciUnit):
         key = self.model.hash() if key is None else key
         disk_cache[key] = results
         disk_cache.close()
+
+    def set_cache(self, results: Any, key: str = None) -> bool:
+        """Store result in disk and/or memory cache for key 'key'.
+
+        Args:
+            results (Any): [description]
+            key (str, optional): [description]. Defaults to None.
+
+        Returns:
+            bool: True if cache was successfully set, else False
+        """
+        if self.use_memory_cache:
+            self.set_memory_cache(results, key=key)
+        if self.use_disk_cache:
+            self.set_disk_cache(results, key=key)
+        if self.use_memory_cache or self.use_disk_cache:
+            return True
+        return False
 
     def load_model(self) -> None:
         """Load the model into memory."""

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -589,12 +589,12 @@ class Test(SciUnit):
                 result = "\n".join(s)
         return result
 
-    def get_cache(self, model: Model, key: Optional[str]=None): -> Any
+    def get_backend_cache(self, model: Model, key: Optional[str]=None): -> Any
         """Get the cached results from the model's backend with the given key
         (defaults to the id of the test instance).
 
         Returns:
-            a cached function output, or None
+            Any: The cache for key 'key' or None if not found.
         """
         if key is None:
             if hasattr(self, id):
@@ -602,17 +602,11 @@ class Test(SciUnit):
             else:
                 return None
 
-        cached_output = None
-
         if hasattr(model, 'backend') and not model.backend is None:
-            # memory cache has priority
-            if model._backend.use_memory_cache:
-                cached_output = model._backend.get_memory_cache(key=key)
-            elif model._backend.use_disk_cache:
-                cached_output = model._backend.get_disk_cache(key=key)
-        return cached_output
+            return model._backend.get_cache(key=key)
+        return None
 
-    def set_cache(self, model: Model, function_output: Any,
+    def set_backend_cache(self, model: Model, function_output: Any,
                   key: Optional[str]=None): -> bool
         """Set the cache of the model's backend with the given key (defaults to
         the id of the test instance)to calculated function output.
@@ -626,14 +620,8 @@ class Test(SciUnit):
             else:
                 return False
 
-        if hasattr(model, 'backend') and not model.backend is None:
-            # memory cache has priority
-            if model._backend.use_memory_cache:
-                model._backend.set_memory_cache(function_output, key=key)
-            if model._backend.use_disk_cache:
-                model._backend.set_disk_cache(function_output, key=key)
-            if model._backend.use_memory_cache or model._backend.use_disk_cache:
-                return True
+        if hasattr(model, 'backend') and model.backend is not None:
+            return model._backend.set_cache(function_output, key=key)
         return False
 
     @property
@@ -987,7 +975,7 @@ class RangeTest(Test):
         assert len(observation) == 2
         assert observation[1] > observation[0]
 
-    @use_cache
+    @use_backend_cache
     def generate_prediction(self, model: Model) -> float:
         """Using the model to generate a prediction.
 

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -19,7 +19,7 @@ from .errors import (
 )
 from .models import Model
 from .scores import BooleanScore, ErrorScore, NAScore, NoneScore, Score, TBDScore
-from .utils import dict_combine
+from .utils import dict_combine, use_backend_cache
 from .validators import ObservationValidator, ParametersValidator
 
 
@@ -260,6 +260,7 @@ class Test(SciUnit):
             model (Model): A sciunit model instance.
         """
 
+    @use_backend_cache
     def generate_prediction(self, model: Model) -> None:
         """Generate a prediction from a model using the required capabilities.
 
@@ -979,7 +980,6 @@ class RangeTest(Test):
         assert len(observation) == 2
         assert observation[1] > observation[0]
 
-    @use_backend_cache
     def generate_prediction(self, model: Model) -> float:
         """Using the model to generate a prediction.
 

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -596,6 +596,8 @@ class Test(SciUnit):
         Returns:
             Any: The cache for key 'key' or None if not found.
         """
+        if model is None:
+            return None
         if key is None:
             if hasattr(self, id):
                 key = self.id
@@ -614,6 +616,8 @@ class Test(SciUnit):
         Returns:
             bool: True if cache was successfully set, else False
         """
+        if model is None:
+            return False
         if key is None:
             if hasattr(self, id):
                 key = self.id

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -610,7 +610,7 @@ class Test(SciUnit):
         return None
 
     def set_backend_cache(self, model: Model, function_output: Any,
-                  key: Optional[str]=None): -> bool
+                  key: Optional[str]=None) -> bool:
         """Set the cache of the model's backend with the given key (defaults to
         the id of the test instance)to calculated function output.
 

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -600,7 +600,7 @@ class Test(SciUnit):
         if model is None:
             return None
         if key is None:
-            if hasattr(self, id):
+            if hasattr(self, 'id'):
                 key = self.id
             else:
                 return None

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -620,7 +620,7 @@ class Test(SciUnit):
         if model is None:
             return False
         if key is None:
-            if hasattr(self, id):
+            if hasattr(self, 'id'):
                 key = self.id
             else:
                 return False

--- a/sciunit/tests.py
+++ b/sciunit/tests.py
@@ -590,7 +590,7 @@ class Test(SciUnit):
                 result = "\n".join(s)
         return result
 
-    def get_backend_cache(self, model: Model, key: Optional[str]=None): -> Any
+    def get_backend_cache(self, model: Model, key: Optional[str]=None) -> Any:
         """Get the cached results from the model's backend with the given key
         (defaults to the id of the test instance).
 

--- a/sciunit/utils.py
+++ b/sciunit/utils.py
@@ -1063,7 +1063,14 @@ def use_backend_cache(original_function=None, cache_key_param=None):
 
             cache_key = None
             if cache_key_param:
-                cache_key = self.params[cache_key_param]
+                if cache_key_param in self.params:
+                    cache_key = self.params[cache_key_param]
+                else:
+                    model = None
+                    warnings.warn("The value for the decorator arguement "
+                                  "cache_key_param value can not be found in "
+                                  "self.params! Caching is skipped.")
+
 
             function_output = self.get_backend_cache(model=model,
                                                      key=cache_key)

--- a/sciunit/utils.py
+++ b/sciunit/utils.py
@@ -1026,11 +1026,50 @@ def memoize(fn=None):
 
     return decorated
 
-
 class_intern = intern.intern
 
 method_memoize = memoize
 
+def use_cache(original_function=None, cache_key_param=None):
+    """
+    Decorator for test functions (in particular `generate_prediction`) to cache
+    the function output on the first execution and return the output from the
+    cache without recomputing on any subsequent execution.
+    The function needs to take a model as an argument, and the caching relies on
+    the model's backend. If it doesn't have a backend the caching step is
+    skipped.
+    Per default, a test instance specific hash is used to link the model to the
+    test's function output. However, optionally, a custom hash key name can be
+    passed to the decorator to use the hash stored in
+    `self.params[<hash key name>]` instead (e.g. for using a shared cache for
+    redundant calculations on the same model across tests).
+    """
+
+    def _decorate(function):
+
+        @functools.wraps(function)
+        def wrapper(self, model, **kwargs):
+            cache_key = None
+            if cache_key_param:
+                cache_key = self.params[cache_key_param]
+
+            function_output = self.get_cache(model=model,
+                                             key=cache_key)
+
+            if function_output is None:
+                function_output = function(self, model=model, **kwargs)
+                self.set_cache(model=model,
+                               function_output=function_output,
+                               key=cache_key)
+
+            return function_output
+
+        return wrapper
+
+    if original_function:
+        return _decorate(original_function)
+    else:
+        return _decorate
 
 def style():
     """Style a notebook with the current sciunit CSS file"""
@@ -1056,7 +1095,7 @@ def style():
     display(
         HTML(
             """
-                 <style>  
+                 <style>
                  %s
                  </style>
                  """

--- a/sciunit/utils.py
+++ b/sciunit/utils.py
@@ -1030,7 +1030,7 @@ class_intern = intern.intern
 
 method_memoize = memoize
 
-def use_cache(original_function=None, cache_key_param=None):
+def use_backend_cache(original_function=None, cache_key_param=None):
     """
     Decorator for test functions (in particular `generate_prediction`) to cache
     the function output on the first execution and return the output from the
@@ -1053,14 +1053,14 @@ def use_cache(original_function=None, cache_key_param=None):
             if cache_key_param:
                 cache_key = self.params[cache_key_param]
 
-            function_output = self.get_cache(model=model,
-                                             key=cache_key)
+            function_output = self.get_backend_cache(model=model,
+                                                     key=cache_key)
 
             if function_output is None:
                 function_output = function(self, model=model, **kwargs)
-                self.set_cache(model=model,
-                               function_output=function_output,
-                               key=cache_key)
+                self.set_backend_cache(model=model,
+                                       function_output=function_output,
+                                       key=cache_key)
 
             return function_output
 

--- a/sciunit/utils.py
+++ b/sciunit/utils.py
@@ -1054,7 +1054,6 @@ def use_backend_cache(original_function=None, cache_key_param=None):
                 model = kwargs['model']
             elif 'model' in sig.parameters.keys():
                 model = args[list(sig.parameters.keys()).index('model')-1]
-                print(model)
             else:
                 model = None
                 warnings.warn("The decorator `use_backend_cache` can only "

--- a/sciunit/utils.py
+++ b/sciunit/utils.py
@@ -1071,7 +1071,6 @@ def use_backend_cache(original_function=None, cache_key_param=None):
                                   "cache_key_param value can not be found in "
                                   "self.params! Caching is skipped.")
 
-
             function_output = self.get_backend_cache(model=model,
                                                      key=cache_key)
 


### PR DESCRIPTION
This PR addresses issue #198 and enables the storing of intermediate test results (incl. predictions) of test classes specific for each model by using their corresponding backend cache. (developed together with @morales-gregorio)

New features:
* Each test instances is assigned an `id` (using *uuid4*) upon creation.
* Backends have the new helper functions `get_cache` and `set_cache` to not require a developer/user to separately address the memory cache and disk cache.
* Tests have the helper functions `set_backend_cache` and `get_backend_cache` to handle a given model's backend cache for a given key (which is the test id by default).
* Utils offers a new decorator `use_backend_cache` that caches the output of test class functions, to avoid multiple calculation.
    * In particular, this is thought to be used with the `generate_prediction` function.
    * The decorator can only be applied to functions that get `model` as an argument, otherwise there will be a warning and the caching will be skipped. If the model doesn't have a backend defined the caching is also skipped.
    * The decorator can also be used with other function, e.g. for sharing the results of expensive computations (like correlation matrices) across tests. For that the argument `cache_key_param` can be passed to the decorator for that function, with a string value. This string value should exist as a key in `self.params` and the corresponding value is then used as cache key.

Example:

```python
from sciunit.utils import use_backend_cache

class correlation_test(sciunit.Test):

    @use_backend_cache(cache_key_param='correlation_cache_key')
    def calc_correlation(self, model):
        ...
        return correlation


class correlation_avg_test(correlation_test):

    default_params = {'correlation_cache_key': '1234'}

    @use_backend_cache
    def generate_prediction(self, model):
        return np.avg(self.calc_correlation(model))


class correlation_std_test(correlation_test):

    default_params = {'correlation_cache_key': '1234'}

    @use_backend_cache
    def generate_prediction(self, model):
        return np.std(self.calc_correlation(model))


avg_corr_test = correlation_avg_test()
std_corr_test = correlation_std_test()

avg_corrsA = avg_corr_test.generate_prediction(modelA)

# the prediction is computed from scratch because the model is different
avg_corrsB = avg_corr_test.generate_prediction(modelB)

# calling the same function again just reads the result from cache
avg_corrsB = avg_corr_test.generate_prediction(modelB)

# this execution is now faster because the raw correlations are already computed
# and cached specific for modelA with key '1234'
std_corrsA = std_corr_test.generate_prediction(modelA)
```
