### PR TITLE
Passing parameters to parents of RunnableModel

### DIFF
--- a/sciunit/models/runnable.py
+++ b/sciunit/models/runnable.py
@@ -18,8 +18,9 @@ class RunnableModel(Model, cap.Runnable):
         name,  # Name of the model
         backend=None,  # Backend to run the models
         attrs=None,  # Optional dictionary of model attributes
+        **params,
     ):
-        super(RunnableModel, self).__init__(name=name)
+        super(RunnableModel, self).__init__(name=name, **params)
         self.skip_run = False  # Backend can use this to skip simulation
         self.run_params = {}  # Should be reset between tests
         self.print_run_params = False  # Print the run parameters with each run


### PR DESCRIPTION
Any additional parameters to the Model class are set as `params`. However, this is not the case for its child class RunnableModel, and therefore can't be used for child classes derived from it. To handle parameter input consistently they should be passed all the way up to the Model class. So, this PR adds `**params` to the RunnableModel init and to its super call.