### PR TITLE
Import CellExecutionError from nbclient, not nbconvert

### DIFF
--- a/sciunit/utils.py
+++ b/sciunit/utils.py
@@ -26,7 +26,7 @@ import nbconvert
 import nbformat
 from IPython.display import HTML, display
 from nbconvert.preprocessors import ExecutePreprocessor
-from nbconvert.preprocessors.execute import CellExecutionError
+from nbclient.exceptions import CellExecutionError
 from quantities.dimensionality import Dimensionality
 from quantities.quantity import Quantity
 


### PR DESCRIPTION
To make sciunit compatible with nbconvert 7.13.0.

Fixes: #220 