### PR TITLE
remove version constraint of importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
   cerberus>=1.2
   deepdiff
   gitpython
-  importlib-metadata<4.0
+  importlib-metadata
   ipykernel
   ipython
   jsonpickle


### PR DESCRIPTION
Removing the version dependency `importlib-metadata < 4.0`. Addressing issue #222
When upgrading the package to its latest version `7.0.1`, the output of the unit tests is unchanged.
There is a failing test `Level 100:sciunit_scores:Score: Fail for UniformModel on RangeTest`, but this is independent of the importlib-metadata version.